### PR TITLE
Added support for building debian package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@
 3. `npm install`
 4. `npm run start`
 
+### Building debian package
+
+1. `git clone git@github.com:landsman/photopea-desktop.git`
+2. `cd photopea-desktop`
+3. `npm install`
+4. `npm run package-linux`
+5. `npm run build-debian`
+
 ## Useful dev links
 - https://www.christianengvall.se/electron-packager-tutorial/
 - https://electron.atom.io/docs/tutorial/application-packaging/#generating-asar-archive

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 1. `git clone git@github.com:landsman/photopea-desktop.git`
 2. `cd photopea-desktop`
-3. `npm run install`
+3. `npm install`
 4. `npm run start`
 
 ## Useful dev links

--- a/debian.json
+++ b/debian.json
@@ -1,0 +1,16 @@
+{
+  "dest": "release-builds/",
+  "icon": "assets/icons/png/256.png",
+  "categories": [
+    "Graphics"
+  ],
+  "name": "photopea-desktop",
+  "productName": "Photopea Desktop",
+  "genericName": "Image Manipulation Program",
+  "description": "Free advanced image editor",
+  "productDescription": "Photopea Desktop is the unofficial desktop client of the free online tool Photopea.  Used for editing raster art and vector graphics with support for PSD, XCF and Sketch files.",
+  "section": "Graphics",
+  "lintianOverrides": [
+    "changelog-file-missing-in-native-package"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
     "dist": "electron-builder",
     "package-mac": "electron-packager . --overwrite --platform=darwin --arch=x64 --icon=assets/icons/mac/icon.icns --prune=true --out=release-builds",
     "package-win": "electron-packager . photopea-desktop --overwrite --asar --platform=win32 --arch=ia32 --icon=assets/icons/win/icon.ico --prune=true --out=release-builds --version-string.CompanyName=CE --version-string.FileDescription=CE --version-string.ProductName=\"Photopea Desktop\"",
-    "package-linux": "electron-packager . photopea-desktop --overwrite --asar=true --platform=linux --arch=x64 --icon=assets/icons/png/128x128.png --prune=true --out=release-builds"
+    "package-linux": "electron-packager . photopea-desktop --overwrite --asar=true --platform=linux --arch=x64 --icon=assets/icons/png/128x128.png --prune=true --out=release-builds",
+    "build-debian": "electron-installer-debian --src=release-builds/photopea-desktop-linux-x64/ --arch=amd64 --config=debian.json"
   },
   "devDependencies": {
     "electron": "^7.1.9",
     "electron-builder": "^22.2.0",
-    "electron-packager": "^9.1.0"
+    "electron-packager": "^9.1.0",
+    "electron-installer-debian": "^0.6.0"
   },
   "dependencies": {
     "dotenv": "^8.2.0"


### PR DESCRIPTION
Could not find any existing debian packages for this tool and so just decided to implement it myself.

I was a little unsure about the formatting of the way in which building should be described in the README but I just tried to emulate the way in which previously written development instructions were presented.

Maybe the debian package file could then be added to releases?